### PR TITLE
Add DBus functionality to VRRP

### DIFF
--- a/keepalived/core/namespaces.c
+++ b/keepalived/core/namespaces.c
@@ -84,8 +84,8 @@
  * # ip netns exec netns2 ip link set eth0 netns netns3
  *
  * Make the link names in netns2 easier to remember
- * # ip netns exec netns1 ip link set 1.eth0 name eth0
- * # ip netns exec netns1 ip link set 3.eth1 name eth1
+ * # ip netns exec netns2 ip link set 1.eth0 name eth0
+ * # ip netns exec netns2 ip link set 3.eth1 name eth1
  *
  * Bring up the interfaces
  * # ip netns exec netns1 ip link set eth0 up
@@ -104,7 +104,7 @@
  * Configure some addresses
  * # ip netns exec netns1 ip addr add 10.2.0.1/24 broadcast 10.2.0.255 dev eth0
  * # ip netns exec netns2 ip addr add 10.2.0.2/24 broadcast 10.2.0.255 dev br0
- * # ip netns exec netns1 ip addr add 10.2.0.3/24 broadcast 10.2.0.255 dev eth0
+ * # ip netns exec netns3 ip addr add 10.2.0.3/24 broadcast 10.2.0.255 dev eth0
  *
  * Test it
  * # ip netns exec netns1 ping 10.2.0.2		# netns1 can talk to netns2
@@ -118,6 +118,8 @@
  * Create three configuration files, keepalived.netns1.conf etc
  * and in each config file in the global_defs section specify
  * net_namespace netns1        # or netns2 or netns3 as appropriate
+ * global_defs {
+ *		....    
  *
  * Now run three instances of keepalived. Note, keepalived handles
  * joining the appropriate network namespace, and so the commands don't

--- a/keepalived/include/vrrp.h
+++ b/keepalived/include/vrrp.h
@@ -324,6 +324,7 @@ extern bool vrrp_ipvs_needed(void);
 #endif
 extern void restore_vrrp_interfaces(void);
 extern void shutdown_vrrp_instances(void);
+extern void find_new_vrrp(void (*f)(vrrp_t *));
 extern void clear_diff_vrrp(void);
 extern void clear_diff_script(void);
 extern void vrrp_restore_interface(vrrp_t *, bool, bool);

--- a/keepalived/include/vrrp_dbus.h
+++ b/keepalived/include/vrrp_dbus.h
@@ -38,6 +38,7 @@
 #define DBUS_VRRP_INSTANCE_INTERFACE_FILE_PATH  "/usr/share/dbus-1/interfaces/org.keepalived.Vrrp1.Instance.xml"
 
 void dbus_send_state_signal(vrrp_t *);
+void dbus_create_object(vrrp_t *);
 void dbus_remove_object(vrrp_t *);
 bool dbus_start(void);
 void dbus_stop(void);

--- a/keepalived/include/vrrp_dbus.h
+++ b/keepalived/include/vrrp_dbus.h
@@ -38,6 +38,7 @@
 #define DBUS_VRRP_INSTANCE_INTERFACE_FILE_PATH  "/usr/share/dbus-1/interfaces/org.keepalived.Vrrp1.Instance.xml"
 
 void dbus_send_state_signal(vrrp_t *);
+void dbus_remove_object(vrrp_t *);
 bool dbus_start(void);
 void dbus_stop(void);
 

--- a/keepalived/include/vrrp_dbus.h
+++ b/keepalived/include/vrrp_dbus.h
@@ -31,9 +31,9 @@
 /* Defines */
 #define DBUS_SERVICE_NAME                       "org.keepalived.Vrrp1"
 #define DBUS_VRRP_INTERFACE                     "org.keepalived.Vrrp1.Vrrp"
-#define DBUS_VRRP_OBJECT                        "/org/keepalived/Vrrp1/Vrrp"
+#define DBUS_VRRP_OBJECT_ROOT                   "/org/keepalived/Vrrp1"
+#define DBUS_VRRP_INSTANCE_PATH_DEFAULT_LENGTH  7
 #define DBUS_VRRP_INSTANCE_INTERFACE            "org.keepalived.Vrrp1.Instance"
-#define DBUS_VRRP_INSTANCE_OBJECT_ROOT          "/org/keepalived/Vrrp1/Instance/"
 #define DBUS_VRRP_INTERFACE_FILE_PATH           "/usr/share/dbus-1/interfaces/org.keepalived.Vrrp1.Vrrp.xml"
 #define DBUS_VRRP_INSTANCE_INTERFACE_FILE_PATH  "/usr/share/dbus-1/interfaces/org.keepalived.Vrrp1.Instance.xml"
 

--- a/keepalived/include/vrrp_dbus.h
+++ b/keepalived/include/vrrp_dbus.h
@@ -32,7 +32,7 @@
 #define DBUS_SERVICE_NAME                       "org.keepalived.Vrrp1"
 #define DBUS_VRRP_INTERFACE                     "org.keepalived.Vrrp1.Vrrp"
 #define DBUS_VRRP_OBJECT_ROOT                   "/org/keepalived/Vrrp1"
-#define DBUS_VRRP_INSTANCE_PATH_DEFAULT_LENGTH  7
+#define DBUS_VRRP_INSTANCE_PATH_DEFAULT_LENGTH  8
 #define DBUS_VRRP_INSTANCE_INTERFACE            "org.keepalived.Vrrp1.Instance"
 #define DBUS_VRRP_INTERFACE_FILE_PATH           "/usr/share/dbus-1/interfaces/org.keepalived.Vrrp1.Vrrp.xml"
 #define DBUS_VRRP_INSTANCE_INTERFACE_FILE_PATH  "/usr/share/dbus-1/interfaces/org.keepalived.Vrrp1.Instance.xml"

--- a/keepalived/share/dbus-1/interfaces/org.keepalived.Vrrp1.Instance.xml
+++ b/keepalived/share/dbus-1/interfaces/org.keepalived.Vrrp1.Instance.xml
@@ -1,13 +1,31 @@
 <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
 "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
 <node>
- <interface name='org.keepalived.Vrrp1.Instance'>
-     <method name='SendGarp'>
-     </method>
-     <signal name='VrrpStatusChange'>
-         <arg type='u' name='status' />
-     </signal>
-     <property type='s' name='Name' access='read' />
-     <property type='u' name='State' access='read' />
+  <!--
+	org.keepalived.Vrrp1.Instance:
+	@short_description: interface for a single VRRP instance
+
+	Exposes methods, signals and properties for a VRRP instance,
+	uniquely identified by its interface, group and family.
+  -->
+  <interface name='org.keepalived.Vrrp1.Instance'>
+	<!--
+	  SendGarp:
+
+	  Sends a single gratuitious ARP request from the instance.
+	-->
+	<method name='SendGarp'>
+	</method>
+	<!--
+	  VrrpStatusChange:
+	  @status: numerical value defining the state.
+
+	  Emitted whenever the instance transitions to a new state.
+	-->
+	<signal name='VrrpStatusChange'>
+	  <arg type='u' name='status' />
+	</signal>
+	<property type='s' name='Name' access='read' />
+	<property type='u' name='State' access='read' />
   </interface>
 </node>

--- a/keepalived/share/dbus-1/interfaces/org.keepalived.Vrrp1.Vrrp.xml
+++ b/keepalived/share/dbus-1/interfaces/org.keepalived.Vrrp1.Vrrp.xml
@@ -6,6 +6,14 @@
     </method>
     <method name='PrintStats'>
 	</method>
+	<method name='CreateInstance'>
+		<arg name="iname" type="s" direction="in" />
+		<arg name="interface" type="s" direction="in" />
+		<arg name="group" type="u" direction="in" />
+	</method>
+	<method name='DestroyInstance'>
+		<arg name="iname" type="s" direction="in" />
+	</method>
 	<signal name="VrrpStopped">
 	</signal>
   </interface>

--- a/keepalived/share/dbus-1/interfaces/org.keepalived.Vrrp1.Vrrp.xml
+++ b/keepalived/share/dbus-1/interfaces/org.keepalived.Vrrp1.Vrrp.xml
@@ -10,6 +10,7 @@
 		<arg name="iname" type="s" direction="in" />
 		<arg name="interface" type="s" direction="in" />
 		<arg name="group" type="u" direction="in" />
+		<arg name="family" type="u" direction="in" />
 	</method>
 	<method name='DestroyInstance'>
 		<arg name="iname" type="s" direction="in" />

--- a/keepalived/share/dbus-1/interfaces/org.keepalived.Vrrp1.Vrrp.xml
+++ b/keepalived/share/dbus-1/interfaces/org.keepalived.Vrrp1.Vrrp.xml
@@ -1,20 +1,71 @@
 <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
 "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
 <node>
+  <!--
+	   org.freedesktop.DBus.Properties:
+	   @short_description: General VRRP interface
+
+	   Interface implemented by a single VRRP object,
+	   exposes some VRRP utility methods and signals.
+  -->
   <interface name='org.keepalived.Vrrp1.Vrrp'>
-    <method name='PrintData'>
-    </method>
-    <method name='PrintStats'>
+	<!--
+	  PrintData:
+
+	  Signals VRRP process to print contents of vrrp_data
+	  in file /tmp/keepalived.data
+	-->
+	<method name='PrintData'>
 	</method>
+	<!--
+	  PrintStats:
+
+	  Signals VRRP process to print stats in file
+	  /tmp/keepalived.stats
+	-->
+	<method name='PrintStats'>
+	</method>
+	<!--
+	  CreateInstance:
+	  @iname: unique name for the new instance.
+	  @interface: interface the instance will use.
+	  @group: VRRP group for the new instance.
+	  @family: IPv\# version (either 4 or 6).
+
+	  Creates new VRRP instance object at the path built
+	  from the given parameters, implementing interface
+	  org.keepalived.Vrrp1.Instance.
+	  @iname must be unique to this object.
+	  For every object created, there must also be an
+	  actual VRRP instance, else all methods called on
+	  this object will fail.
+	-->
 	<method name='CreateInstance'>
-		<arg name="iname" type="s" direction="in" />
-		<arg name="interface" type="s" direction="in" />
-		<arg name="group" type="u" direction="in" />
-		<arg name="family" type="u" direction="in" />
+	  <arg name="iname" type="s" direction="in" />
+	  <arg name="interface" type="s" direction="in" />
+	  <arg name="group" type="u" direction="in" />
+	  <arg name="family" type="u" direction="in" />
 	</method>
+	<!--
+	  DestroyInstance:
+	  @iname: name of the instance to be destroyed.
+
+	  Deletes from the bus a VRRP instance object
+	  identified by the iname value. If no such object
+	  exists, method has no effect.
+	  Only deletes the DBus object for the instance, to
+	  successfully remove an instance it must also be
+	  deleted from VRRP.
+	-->
 	<method name='DestroyInstance'>
 		<arg name="iname" type="s" direction="in" />
 	</method>
+	<!--
+	  VrrpStopped:
+
+	  Emitted when VRRP process is terminated, just before
+	  the bus is disconnected.
+	-->
 	<signal name="VrrpStopped">
 	</signal>
   </interface>

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -61,6 +61,10 @@
 #include "vrrp_iprule.h"
 #include "vrrp_iproute.h"
 #endif
+#ifdef _WITH_DBUS_
+#include "vrrp_dbus.h"
+#include "global_data.h"
+#endif
 
 #include <netinet/ip.h>
 #include <netinet/ip6.h>
@@ -2612,6 +2616,11 @@ clear_diff_vrrp(void)
 			/* Remove VMAC if one was created */
 			if (__test_bit(VRRP_VMAC_BIT, &vrrp->vmac_flags))
 				netlink_link_del_vmac(vrrp);
+#endif
+#ifdef _WITH_DBUS_
+			/* Remove DBus object */
+			if (global_data->enable_dbus)
+				dbus_remove_object(vrrp);
 #endif
 		} else {
 			/*

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -2589,6 +2589,50 @@ reset_vrrp_state(vrrp_t *old_vrrp, vrrp_t *vrrp)
 	}
 }
 
+/* Executes function f on all new vrrp objects */
+void
+find_new_vrrp(void (*f)(vrrp_t *))
+{
+	element e1, e2;
+	list o = old_vrrp_data->vrrp;
+	list n = vrrp_data->vrrp;
+	vrrp_t *vrrp_n, *vrrp_o;
+	vrrp_t * new[LIST_SIZE(n)];
+	int i = 0;
+
+	/* Save all current VRRP instances in array new */
+	for (e1 = LIST_HEAD(n); e1; ELEMENT_NEXT(e1)) {
+		vrrp_n = ELEMENT_DATA(e1);
+		new[i] = vrrp_n;
+		i++;
+	}
+
+	/* Remove all VRRP that existed before from new */
+	for (e1 = LIST_HEAD(o); e1; ELEMENT_NEXT(e1)){
+		vrrp_o = ELEMENT_DATA(e1);
+		/* if vrrp_o doesn't exist anymore it won't be in new */
+		if (vrrp_exist(vrrp_o)) {
+			i = 0;
+			for (e2 = LIST_HEAD(n); e2; ELEMENT_NEXT(e2)){
+				vrrp_n = ELEMENT_DATA(e2);
+				if (strncmp(IF_NAME(IF_BASE_IFP(vrrp_n->ifp)),
+					IF_NAME(IF_BASE_IFP(vrrp_o->ifp)), IFNAMSIZ) == 0
+					&& vrrp_n->vrid == vrrp_o->vrid
+					&& vrrp_n->family == vrrp_o->family)
+				{
+					new[i] = NULL;
+					break;
+				}
+			}
+		}
+	}
+
+	for (i=0; i<LIST_SIZE(n);i++){
+		if (new[i])
+			(*f)(new[i]);
+	}
+}
+
 /* Diff when reloading configuration */
 void
 clear_diff_vrrp(void)

--- a/keepalived/vrrp/vrrp_daemon.c
+++ b/keepalived/vrrp/vrrp_daemon.c
@@ -221,6 +221,9 @@ start_vrrp(void)
 #endif
 
 	if (reload) {
+#ifdef _WITH_DBUS_
+		find_new_vrrp(dbus_create_object);
+#endif
 		clear_diff_saddresses();
 #ifdef _HAVE_FIB_ROUTING_
 		clear_diff_srules();

--- a/keepalived/vrrp/vrrp_dbus.c
+++ b/keepalived/vrrp/vrrp_dbus.c
@@ -488,6 +488,19 @@ dbus_send_state_signal(vrrp_t *vrrp)
 	g_free(object_path);
 }
 
+void dbus_remove_object(vrrp_t *vrrp)
+{
+	GDBusMethodInvocation *invocation;
+	GVariant *arg = g_variant_new("(s)", vrrp->iname);
+
+	handle_method_call(global_connection,
+						DBUS_SERVICE_NAME,
+						dbus_object_create_path_vrrp(),
+						DBUS_VRRP_INTERFACE,
+						"DestroyInstance",
+						arg, invocation, NULL);
+}
+
 static void
 return_dbus_msg(dbus_queue_ent_t *ent)
 {

--- a/keepalived/vrrp/vrrp_dbus.c
+++ b/keepalived/vrrp/vrrp_dbus.c
@@ -597,7 +597,7 @@ handle_dbus_msg(thread_t *thread)
 		}
 		else if (ent->action == DBUS_DESTROY_INSTANCE) {
 			gchar *key = ent->str;
-			guint value = g_hash_table_lookup(objects, key);
+			gpointer value = g_hash_table_lookup(objects, key);
 			if (value){
 				unregister_object(key, value, NULL);
 				g_hash_table_remove(objects, ent->str);

--- a/keepalived/vrrp/vrrp_dbus.c
+++ b/keepalived/vrrp/vrrp_dbus.c
@@ -490,15 +490,7 @@ dbus_send_state_signal(vrrp_t *vrrp)
 
 void dbus_remove_object(vrrp_t *vrrp)
 {
-	GDBusMethodInvocation *invocation;
-	GVariant *arg = g_variant_new("(s)", vrrp->iname);
-
-	handle_method_call(global_connection,
-						DBUS_SERVICE_NAME,
-						dbus_object_create_path_vrrp(),
-						DBUS_VRRP_INTERFACE,
-						"DestroyInstance",
-						arg, invocation, NULL);
+	unregister_object(vrrp->iname, g_hash_table_lookup(objects, vrrp->iname), NULL);
 }
 
 static void

--- a/keepalived/vrrp/vrrp_dbus.c
+++ b/keepalived/vrrp/vrrp_dbus.c
@@ -434,6 +434,10 @@ dbus_main(__attribute__ ((unused)) void *unused)
 		return NULL;
 	}
 	vrrp_introspection_data = g_dbus_node_info_new_for_xml(introspection_xml, &error);
+	if (!vrrp_introspection_data) {
+		log_message(LOG_INFO, "%s", error->message);
+		return NULL;
+	}
 	FREE(introspection_xml);
 
 	introspection_xml = read_file(DBUS_VRRP_INSTANCE_INTERFACE_FILE_PATH);
@@ -442,6 +446,10 @@ dbus_main(__attribute__ ((unused)) void *unused)
 		return NULL;
 	}
 	vrrp_instance_introspection_data = g_dbus_node_info_new_for_xml(introspection_xml, &error);
+	if (!vrrp_instance_introspection_data) {
+		log_message(LOG_INFO, "%s", error->message);
+		return NULL;
+	}
 	FREE(introspection_xml);
 
 	owner_id = g_bus_own_name(G_BUS_TYPE_SYSTEM,


### PR DESCRIPTION
Add new pthread off VRRP to expose DBUs service org.keepalived.Vrrp1
through a GMainLoop.
Create a general /org/keepalived/Vrrp1/Vrrp DBus
object and a /org/keepalived/Vrrp1/Instance/#interface#/#group# object for
each VRRP instance.
Interface org.keepalived.Vrrp1.Vrrp implements methods PrintData,
PrintStats and signal VrrpStopped.
Interface com.keepalived.Vrrp1.Instance implements method SendGarp
(sends a single Gratuitous ARP from the given Instance),
signal VrrpStatusChange, and properties Name and State (retrievable
through calls to org.freedesktop.DBus.Properties.Get)

Interface files are located at location /usr/share/dbus-1/interfaces/
A policy file, which determines who has access to the service, is
located at /etc/dbus-1/system.d/
