### PR TITLE
Allow only properties to be called by everyone

### DIFF
--- a/keepalived/etc/dbus-1/system.d/org.keepalived.Vrrp1.conf
+++ b/keepalived/etc/dbus-1/system.d/org.keepalived.Vrrp1.conf
@@ -2,11 +2,11 @@
 "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
  "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
 <busconfig>
-        <policy user="root">
-                <allow own="org.keepalived.Vrrp1"/>
-                <allow send_destination="org.keepalived.Vrrp1"/>
-        </policy>
-	<policy context="default">
+	<policy user="root">
+		<allow own="org.keepalived.Vrrp1"/>
 		<allow send_destination="org.keepalived.Vrrp1"/>
-        </policy>
+	</policy>
+	<policy context="default">
+		<allow send_interface="org.freedesktop.DBus.Properties" />
+	</policy>
 </busconfig>


### PR DESCRIPTION
Only the root user should be allowed to call Vrrp methods
The org.freedesktop.DBus.Properties interface is implemented by all VRRP Instance objects, and is responsible for reading and writing DBus properties
