### PR TITLE
snap: Build multiple keepalived binaries.

### DIFF
--- a/snap-tools/keepalived-wrapper
+++ b/snap-tools/keepalived-wrapper
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+MAJ_VER=$(uname -r | cut -d'.' -f1)
+MIN_VER=$(uname -r | cut -d'.' -f2)
+RUNNING_KERNEL_VER=$(printf "%d%2.2d\n" $MAJ_VER $MIN_VER)
+if [ ${RUNNING_KERNEL_VER} -ge 418 ]; then
+  BINARY="keepalived-418"
+elif [ ${RUNNING_KERNEL_VER} -ge 415 ]; then
+  BINARY="keepalived-415"
+elif [ ${RUNNING_KERNEL_VER} -ge 404 ]; then
+  BINARY="keepalived-404"
+elif [ ${RUNNING_KERNEL_VER} -ge 313 ]; then
+  BINARY="keepalived-313"
+elif [ ${RUNNING_KERNEL_VER} -ge 305 ]; then
+  BINARY="keepalived-310"
+else
+  echo "ERROR! You are running kernel ${RUNNING_KERNEL_VER},"
+  echo "       which is not currently supported by the keepalived snap."
+  echo "If you need support for kernel ${RUNNING_KERNEL_VER} please file"
+  echo "an issue: https://github.com/acassen/keepalived/issues"
+exit 1
+fi
+
+exec ${SNAP}/usr/sbin/${BINARY} "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -12,33 +12,27 @@ confinement: classic
 apps:
   daemon:
     daemon: forking
-    command: usr/sbin/keepalived
+    command: bin/keepalived-wrapper
   keepalived:
-    command: usr/sbin/keepalived
+    command: bin/keepalived-wrapper
+  "418":
+    command: usr/sbin/keepalived-418
+  "415":
+    command: usr/sbin/keepalived-415
+  "404":
+    command: usr/sbin/keepalived-404
+  "313":
+    command: usr/sbin/keepalived-313
+  "310":
+    command: usr/sbin/keepalived-310
   genhash:
     command: usr/bin/genhash
 
 parts:
-  linux-headers:
-    plugin: dump
-    source: http://security.ubuntu.com/ubuntu/pool/main/l/linux/linux-libc-dev_3.13.0-161.211_amd64.deb
-    override-build: |
-      snapcraftctl build
-      # Move the headers on the host out of the way
-      mv /usr/include/linux /opt/linux || true
-      # Move header from the part to the host
-      mv usr/include/linux /usr/include/  || true
-    stage:
-      - -*
-    prime:
-      - -*
-
   keepalived:
     plugin: autotools
     source: .
     source-type: git
-    after:
-      - linux-headers
     configflags:
       - --prefix=/usr
       - --enable-bfd
@@ -74,3 +68,168 @@ parts:
       - libnl-genl-3-200
       - libpcre2-8-0
       - libsnmp30
+    organize:
+      'usr/sbin/keepalived': usr/sbin/keepalived-404
+
+  linux-headers-418:
+    plugin: dump
+    source: http://security.ubuntu.com/ubuntu/pool/main/l/linux/linux-libc-dev_4.18.0-10.11_amd64.deb
+    after:
+      - keepalived
+    override-build: |
+      snapcraftctl build
+      # Move the headers on the host out of the way
+      rm -rf /usr/include/linux || true
+      # Move header from the part to the host
+      mv usr/include/linux /usr/include/  || true
+    stage:
+      - -*
+    prime:
+      - -*
+
+  keepalived-418:
+    plugin: autotools
+    source: .
+    source-type: git
+    after:
+      - keepalived
+      - linux-headers-418
+    configflags:
+      - --prefix=/usr
+      - --enable-bfd
+      - --enable-dbus
+      - --enable-json
+      - --enable-regex
+      - --enable-snmp
+      - --enable-snmp-rfc
+      - --disable-libipset-dynamic
+    organize:
+      'usr/sbin/keepalived': usr/sbin/keepalived-418
+    stage:
+      - usr/sbin/keepalived-418
+    prime:
+      - usr/sbin/keepalived-418
+
+  linux-headers-415:
+    plugin: dump
+    source: http://launchpadlibrarian.net/394599433/linux-libc-dev_4.15.0-39.42_amd64.deb
+    after:
+      - keepalived-418
+    override-build: |
+      snapcraftctl build
+      # Move the headers on the host out of the way
+      rm -rf /usr/include/linux || true
+      # Move header from the part to the host
+      mv usr/include/linux /usr/include/  || true
+    stage:
+      - -*
+    prime:
+      - -*
+
+  keepalived-415:
+    plugin: autotools
+    source: .
+    source-type: git
+    after:
+      - keepalived-418
+      - linux-headers-415
+    configflags:
+      - --prefix=/usr
+      - --enable-bfd
+      - --enable-dbus
+      - --enable-json
+      - --enable-regex
+      - --enable-snmp
+      - --enable-snmp-rfc
+      - --disable-libipset-dynamic
+    organize:
+      'usr/sbin/keepalived': usr/sbin/keepalived-415
+    stage:
+      - usr/sbin/keepalived-415
+    prime:
+      - usr/sbin/keepalived-415
+
+
+  linux-headers-313:
+    plugin: dump
+    source: http://security.ubuntu.com/ubuntu/pool/main/l/linux/linux-libc-dev_3.13.0-161.211_amd64.deb
+    after:
+      - keepalived-415
+    override-build: |
+      snapcraftctl build
+      # Move the headers on the host out of the way
+      rm -rf /usr/include/linux || true
+      # Move header from the part to the host
+      mv usr/include/linux /usr/include/  || true
+    stage:
+      - -*
+    prime:
+      - -*
+
+  keepalived-313:
+    plugin: autotools
+    source: .
+    source-type: git
+    after:
+      - keepalived-415
+      - linux-headers-313
+    configflags:
+      - --prefix=/usr
+      - --enable-bfd
+      - --enable-dbus
+      - --enable-json
+      - --enable-regex
+      - --enable-snmp
+      - --enable-snmp-rfc
+      - --disable-libipset-dynamic
+    organize:
+      'usr/sbin/keepalived': usr/sbin/keepalived-313
+    stage:
+      - usr/sbin/keepalived-313
+    prime:
+      - usr/sbin/keepalived-313
+
+  linux-headers-310:
+    plugin: dump
+    source: http://launchpadlibrarian.net/144719237/linux-libc-dev_3.10.0-2.11_amd64.deb
+    after:
+      - keepalived-313
+    override-build: |
+      snapcraftctl build
+      # Move the headers on the host out of the way
+      rm -rf /usr/include/linux || true
+      # Move header from the part to the host
+      mv usr/include/linux /usr/include/  || true
+    stage:
+      - -*
+    prime:
+      - -*
+
+  keepalived-310:
+    plugin: autotools
+    source: .
+    source-type: git
+    after:
+      - keepalived-313
+      - linux-headers-310
+    configflags:
+      - --prefix=/usr
+      - --enable-bfd
+      - --enable-dbus
+      - --enable-json
+      - --enable-regex
+      - --enable-snmp
+      - --enable-snmp-rfc
+      - --disable-libipset-dynamic
+    organize:
+      'usr/sbin/keepalived': usr/sbin/keepalived-310
+    stage:
+      - usr/sbin/keepalived-310
+    prime:
+      - usr/sbin/keepalived-310
+
+  keepalived-wrapper:
+    plugin: dump
+    source: snap-tools
+    organize:
+      'keepalived-wrapper': bin/


### PR DESCRIPTION
Build multiple `keepalived` binaries inside the snap and add a wrapper so the most suitable version is used.